### PR TITLE
Remove encoding parameter

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -45,7 +45,7 @@ def escape_param(s):
 def rpc(method, **params):
     params = json.dumps(params)
     query = b'{"jsonrpc": "2.0", "method": "%s", "params": %s, "id": 1}' % (method.encode(), params.encode())
-    return json.loads(xbmc.executeJSONRPC(query.decode()), encoding='utf-8')
+    return json.loads(xbmc.executeJSONRPC(query.decode()))
 
 
 def _split_multipaths(paths):


### PR DESCRIPTION
Changed in version 3.9: The keyword argument `encoding` has been removed.
[Python documentation](https://docs.python.org/3/library/json.html#json.loads)

Fixes this. Kodi complains and the service shutsdown. 

```
2021-08-08 07:48:06.092 T:51719   ERROR <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'TypeError'>
                                                   Error Contents: __init__() got an unexpected keyword argument 'encoding'
                                                   Traceback (most recent call last):
                                                     File "/home/gimix/.kodi/addons/service.librarywatchdog/service.py", line 23, in <module>
                                                       from core import main
                                                     File "/home/gimix/.kodi/addons/service.librarywatchdog/core/main.py", line 27, in <module>
                                                       from . import settings
                                                     File "/home/gimix/.kodi/addons/service.librarywatchdog/core/settings.py", line 41, in <module>
                                                       VIDEO_SOURCES = utils.get_media_sources('video')
                                                     File "/home/gimix/.kodi/addons/service.librarywatchdog/core/utils.py", line 64, in get_media_sources
                                                       response = rpc('Files.GetSources', media=media_type)
                                                     File "/home/gimix/.kodi/addons/service.librarywatchdog/core/utils.py", line 48, in rpc
                                                       return json.loads(xbmc.executeJSONRPC(query.decode()), encoding='utf-8')
                                                     File "/usr/lib/python3.9/json/__init__.py", line 359, in loads
                                                       return cls(**kw).decode(s)
                                                   TypeError: __init__() got an unexpected keyword argument 'encoding'
                                                   -->End of Python script error report<--

2021-08-08 07:48:06.094 T:51719    INFO <general>: Python interpreter stopped
```
